### PR TITLE
Increase the DATASIZE to 2G

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -28,7 +28,7 @@ function error {
 }
 
 function set_ulimit {
-    DATASIZE="1572864" #1.5G
+    DATASIZE="2097152" #2G
     
     if [ $(ulimit -Sd) -lt ${DATASIZE} ]; then
 	ulimit -Sd ${DATASIZE} || error "Cannot increase datasize-cur to at least ${DATASIZE}"


### PR DESCRIPTION
The default DATASIZE doesn't seem to be enough as I get:

```
Error occurred during initialization of VM
Could not allocate metaspace: 268435456 bytes 
```

Increasing this to 2GB seems to solve it.