### PR TITLE
s3.amazonaws.com/Minecraft.Download is down

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -16,7 +16,7 @@ PREFIX="/usr/local"
 INITIAL=true
 CONF_FILE=~/.minecraftrc
 CONF_DIR=~/minecraft
-MC_URL="https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.jar"
+MC_URL="https://github.com/glowiak/s3MinecraftDownload/raw/master/launcher.jar"
 
 function msg {
     echo "${bold}${1}${white}"


### PR DESCRIPTION
I don't see any sense in using the official launcher anyway, as it cannot login anymore